### PR TITLE
# Fix: Streaming logs from subprocess to parent stdout immediately

### DIFF
--- a/mlflow/odahuflow/mlflowrunner/runner.py
+++ b/mlflow/odahuflow/mlflowrunner/runner.py
@@ -121,7 +121,7 @@ def save_models(mlflow_run_id: str, model_training: ModelTraining, target_direct
         raise Exception(f'Founded models: {models!r}. Only 1 model allowed')
 
     if not models:
-        raise Exception(f'Can not find any model')
+        raise Exception('Can not find any model')
 
     model = models[0]
     model_source_folder = os.path.join(artifact_uri, model)

--- a/mlflow/odahuflow/mlflowrunner/wrapper/wrapper.py
+++ b/mlflow/odahuflow/mlflowrunner/wrapper/wrapper.py
@@ -72,5 +72,5 @@ def main():
     try:
         work(args.input, args.output)
     except Exception:
-        logging.exception(f'Exception occurs during model training')
+        logging.exception('Exception occurs during model training')
         sys.exit(2)


### PR DESCRIPTION
* Change the way to call subprocess to properly catch stdout and online streaming of training logs to parent
* Fix small linter warnings about f-strings without variables