### PR TITLE
fix. mlfow to gppi args

### DIFF
--- a/mlflow/odahuflow/trainer/helpers/mlflow_helper.py
+++ b/mlflow/odahuflow/trainer/helpers/mlflow_helper.py
@@ -173,7 +173,7 @@ def mlflow_to_gppi(model_meta: ModelIdentity, mlflow_model_path: str, gppi_model
     with open(project_file_path, 'w') as proj_stream:
         yaml.dump(manifest.dict(), proj_stream)
 
-    logging.info("GPPI stored. Start to GPPI validation")
+    logging.info("GPPI stored. Starting GPPI validation")
     mb = GPPITrainedModelBinary(gppi_model_path)
     mb.self_check()
     logging.info("GPPI is validated. OK")
@@ -273,10 +273,11 @@ def mlflow_to_gppi_cli():
                         help='Path to source MLFlow model directory')
     parser.add_argument('--gppi-model-path', '--gppi', required=True,
                         type=dir_type, help='Path to result GPPI model directory')
-    parser.add_argument('--tgz', required=False, default=True,
-                        type=bool, help='Make tar arhieve with gppi folder')
-
+    parser.add_argument('--tgz', dest='tgz', action='store_true', help='Make tar arhieve with gppi folder')
+    parser.add_argument('--no-tgz', dest='tgz', action='store_false')
+    parser.set_defaults(tgz=True)
     args = parser.parse_args()
+
     setup_logging(args)
     gppi_model_path: str = args.gppi_model_path
 

--- a/mlflow/odahuflow/trainer/helpers/mlflow_helper.py
+++ b/mlflow/odahuflow/trainer/helpers/mlflow_helper.py
@@ -279,9 +279,7 @@ def mlflow_to_gppi_cli():
                         type=str, help='Path to source MLFlow model directory')
     parser.add_argument('--gppi-model-path', '--gppi', required=True,
                         type=str, help='Path to result GPPI model directory')
-    parser.add_argument('--tgz', dest='tgz', action='store_true', help='Make tar arhieve with gppi folder')
-    parser.add_argument('--no-tgz', dest='tgz', action='store_false')
-    parser.set_defaults(tgz=True)
+    parser.add_argument('--no-tgz', dest='tgz', action='store_false', help='Prevent archiving result directory')
     args = parser.parse_args()
 
     setup_logging(args)

--- a/mlflow/odahuflow/trainer/helpers/mlflow_helper.py
+++ b/mlflow/odahuflow/trainer/helpers/mlflow_helper.py
@@ -266,9 +266,10 @@ def mlflow_to_gppi_cli():
             raise ValueError(f'A file already exists with the same name: {string}\n'
                              'Rename file or directory and try again.') from error
 
-    def validate_dir(string):
+    def dir_type(string):
         if not os.path.isdir(string):
-            raise ValueError(f'{string} is not a valid directory path')
+            raise ValueError
+        return string
 
     parser = argparse.ArgumentParser(description='Converts MLFLow model to GPPI.')
 
@@ -276,7 +277,7 @@ def mlflow_to_gppi_cli():
     parser.add_argument('--model-name', type=str, required=True, help='Name of GPPI Model')
     parser.add_argument('--model-version', type=str, required=True, help='Version of GPPI Model')
     parser.add_argument('--mlflow-model-path', '--mlflow', required=True,
-                        type=str, help='Path to source MLFlow model directory')
+                        type=dir_type, help='Path to source MLFlow model directory')
     parser.add_argument('--gppi-model-path', '--gppi', required=True,
                         type=str, help='Path to result GPPI model directory')
     parser.add_argument('--no-tgz', dest='tgz', action='store_false', help='Prevent archiving result directory')
@@ -285,7 +286,6 @@ def mlflow_to_gppi_cli():
     setup_logging(args)
     gppi_model_path: str = args.gppi_model_path
 
-    validate_dir(args.mlflow_model_path)
     make_dir(gppi_model_path)
 
     if len(os.listdir(gppi_model_path)) > 0:

--- a/mlflow/odahuflow/trainer/helpers/mlflow_helper.py
+++ b/mlflow/odahuflow/trainer/helpers/mlflow_helper.py
@@ -288,7 +288,7 @@ def mlflow_to_gppi_cli():
                        mlflow_model_path=args.mlflow_model_path,
                        gppi_model_path=gppi_model_path)
 
-        if args.zip:
+        if args.tgz:
             with _remember_cwd(), tarfile.open(f'{gppi_model_path}.tgz', 'w:gz') as tar:  # type: tarfile.TarFile
                 os.chdir(args.gppi_model_path)
                 for s in os.listdir('.'):

--- a/mlflow/odahuflow/trainer/helpers/mlflow_helper.py
+++ b/mlflow/odahuflow/trainer/helpers/mlflow_helper.py
@@ -258,21 +258,27 @@ def _remember_cwd():
 
 
 def mlflow_to_gppi_cli():
-    parser = argparse.ArgumentParser()
 
-    def dir_type(string):
-        os.makedirs(string, exist_ok=True)
+    def make_dir(string):
+        try:
+            os.makedirs(string, exist_ok=True)
+        except FileExistsError as error:
+            raise ValueError(f'A file already exists with the same name: {string}\n'
+                             'Rename file or directory and try again.') from error
+
+    def validate_dir(string):
         if not os.path.isdir(string):
             raise ValueError(f'{string} is not a valid directory path')
-        return string
+
+    parser = argparse.ArgumentParser(description='Converts MLFLow model to GPPI.')
 
     parser.add_argument('--verbose', action='store_true', help='More extensive logging')
     parser.add_argument('--model-name', type=str, required=True, help='Name of GPPI Model')
     parser.add_argument('--model-version', type=str, required=True, help='Version of GPPI Model')
-    parser.add_argument('--mlflow-model-path', '--mlflow', required=True, type=dir_type,
-                        help='Path to source MLFlow model directory')
+    parser.add_argument('--mlflow-model-path', '--mlflow', required=True,
+                        type=str, help='Path to source MLFlow model directory')
     parser.add_argument('--gppi-model-path', '--gppi', required=True,
-                        type=dir_type, help='Path to result GPPI model directory')
+                        type=str, help='Path to result GPPI model directory')
     parser.add_argument('--tgz', dest='tgz', action='store_true', help='Make tar arhieve with gppi folder')
     parser.add_argument('--no-tgz', dest='tgz', action='store_false')
     parser.set_defaults(tgz=True)
@@ -281,7 +287,10 @@ def mlflow_to_gppi_cli():
     setup_logging(args)
     gppi_model_path: str = args.gppi_model_path
 
-    if os.path.exists(gppi_model_path) and len(os.listdir(gppi_model_path)) > 0:
+    validate_dir(args.mlflow_model_path)
+    make_dir(gppi_model_path)
+
+    if len(os.listdir(gppi_model_path)) > 0:
         logging.error("Result directory must be empty!")
 
     try:


### PR DESCRIPTION
- fixes that bool parameter cannot be passed through CLI (for --tgz flag). Ref: https://stackoverflow.com/questions/15008758/parsing-boolean-values-with-argparse
or I can update to this action but it needs python3.8+
``` python
import argparse
parser = argparse.ArgumentParser()
parser.add_argument('--foo', action=argparse.BooleanOptionalAction)
parser.parse_args(['--no-foo'])
Namespace(foo=False)
```

- fixed small bug that when the `--gppi` and `--help` flags are passed, you would create folder when you passed `--gppi` flag and after that `--help` flag.
- completed revert from `--zip` to `--tgz`