### PR TITLE
update Dockerfile for mlflow-toolchain (conda 4.10.3)

### DIFF
--- a/containers/mlflow-toolchain/Dockerfile
+++ b/containers/mlflow-toolchain/Dockerfile
@@ -24,7 +24,7 @@ ENV LANG=C.UTF-8 LC_ALL=C.UTF-8 \
     LD_LIBRARY_PATH="/usr/local/nvidia/lib64:${LD_LIBRARY_PATH}"
 
 RUN apt-get update --fix-missing && \
-    apt-get install -y wget git \
+    apt-get install -y wget git bzip2 ca-certificates \
             # numpy install requirements
             gfortran && \
     apt-get clean && \

--- a/containers/mlflow-toolchain/Dockerfile
+++ b/containers/mlflow-toolchain/Dockerfile
@@ -20,7 +20,7 @@ FROM continuumio/miniconda3:${MINICONDA_VERSION}
 ARG ODAHUFLOW_DIR=/opt/odahu-flow
 
 RUN apt-get update --fix-missing && \
-    apt-get install -y wget bzip2 git build-essential && \
+    apt-get install -y wget git gfortran && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/containers/mlflow-toolchain/Dockerfile
+++ b/containers/mlflow-toolchain/Dockerfile
@@ -1,5 +1,5 @@
 #
-#    Copyright 2019 EPAM Systems
+#    Copyright 2021 EPAM Systems
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -14,44 +14,25 @@
 #    limitations under the License.
 #
 
-FROM ubuntu:18.04
+ARG MINICONDA_VERSION=latest
+FROM continuumio/miniconda3:${MINICONDA_VERSION}
 
-ARG MINICONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-4.7.12-Linux-x86_64.sh
 ARG ODAHUFLOW_DIR=/opt/odahu-flow
-ARG PIP_EXTRA_INDEX_URL
-
-ENV LANG=C.UTF-8 LC_ALL=C.UTF-8 \
-    PATH="/usr/local/nvidia/bin:/opt/conda/bin:${PATH}" \
-    LD_LIBRARY_PATH="/usr/local/nvidia/lib64:${LD_LIBRARY_PATH}"
 
 RUN apt-get update --fix-missing && \
-    apt-get install -y wget bzip2 git && \
+    apt-get install -y wget bzip2 git build-essential && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-# Install conda
-RUN wget --quiet ${MINICONDA_URL} -O ~/miniconda.sh && \
-    /bin/bash ~/miniconda.sh -b -p /opt/conda && \
-    rm ~/miniconda.sh && \
-    conda clean -tipsy && \
-    ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
-    echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
-    echo "conda activate base" >> ~/.bashrc
-
-# Create empty conda environemnt for a model dependencies
-ENV ODAHU_CONDA_ENV_NAME=odahu_model
-ENV PATH=/opt/conda/envs/${ODAHU_CONDA_ENV_NAME}/bin:$PATH
-RUN conda create --name ${ODAHU_CONDA_ENV_NAME} python --no-default-packages
 
 COPY mlflow/requirements.txt "${ODAHUFLOW_DIR}/"
 RUN . /opt/conda/etc/profile.d/conda.sh && \
     conda activate base && \
     pip install --upgrade pip setuptools wheel && \
-    pip install --use-feature=2020-resolver -r "${ODAHUFLOW_DIR}/requirements.txt"
+    pip install -r "${ODAHUFLOW_DIR}/requirements.txt"
 
 COPY mlflow/ "${ODAHUFLOW_DIR}/"
 RUN . /opt/conda/etc/profile.d/conda.sh && \
     conda activate base && \
-    pip install --use-feature=2020-resolver  -e "${ODAHUFLOW_DIR}"
+    pip install -e "${ODAHUFLOW_DIR}"
 
 CMD [ "/bin/bash" ]

--- a/containers/mlflow-toolchain/Dockerfile
+++ b/containers/mlflow-toolchain/Dockerfile
@@ -14,11 +14,11 @@
 #    limitations under the License.
 #
 
-ARG MINICONDA_VERSION=latest
-FROM continuumio/miniconda3:${MINICONDA_VERSION}
+FROM continuumio/miniconda3:4.10.3
 
 ARG ODAHUFLOW_DIR=/opt/odahu-flow
 
+# nvidia CUDA needed for tensorflow-gpu
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8 \
     PATH="/usr/local/nvidia/bin:/opt/conda/bin:${PATH}" \
     LD_LIBRARY_PATH="/usr/local/nvidia/lib64:${LD_LIBRARY_PATH}"
@@ -33,12 +33,12 @@ RUN apt-get update --fix-missing && \
 COPY mlflow/requirements.txt "${ODAHUFLOW_DIR}/"
 RUN . /opt/conda/etc/profile.d/conda.sh && \
     conda activate base && \
-    pip install --upgrade pip setuptools wheel && \
-    pip install -r "${ODAHUFLOW_DIR}/requirements.txt"
+    python3 -m pip install --upgrade pip setuptools wheel && \
+    python3 -m pip install -r "${ODAHUFLOW_DIR}/requirements.txt"
 
 COPY mlflow/ "${ODAHUFLOW_DIR}/"
 RUN . /opt/conda/etc/profile.d/conda.sh && \
     conda activate base && \
-    pip install -e "${ODAHUFLOW_DIR}"
+    python3 -m pip install -e "${ODAHUFLOW_DIR}"
 
 CMD [ "/bin/bash" ]

--- a/containers/mlflow-toolchain/Dockerfile
+++ b/containers/mlflow-toolchain/Dockerfile
@@ -26,6 +26,10 @@ RUN apt-get update --fix-missing && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+# add model conda env to PATH
+ENV ODAHU_CONDA_ENV_NAME=odahu_model
+ENV PATH=/opt/conda/envs/${ODAHU_CONDA_ENV_NAME}/bin:$PATH
+
 COPY mlflow/requirements.txt "${ODAHUFLOW_DIR}/"
 RUN . /opt/conda/etc/profile.d/conda.sh && \
     conda activate base && \

--- a/containers/mlflow-toolchain/Dockerfile
+++ b/containers/mlflow-toolchain/Dockerfile
@@ -19,17 +19,16 @@ FROM continuumio/miniconda3:${MINICONDA_VERSION}
 
 ARG ODAHUFLOW_DIR=/opt/odahu-flow
 
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8 \
+    PATH="/usr/local/nvidia/bin:/opt/conda/bin:${PATH}" \
+    LD_LIBRARY_PATH="/usr/local/nvidia/lib64:${LD_LIBRARY_PATH}"
+
 RUN apt-get update --fix-missing && \
     apt-get install -y wget git \
             # numpy install requirements
             gfortran && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-# Create empty conda environemnt for a model dependencies
-ENV ODAHU_CONDA_ENV_NAME=odahu_model
-ENV PATH=/opt/conda/envs/${ODAHU_CONDA_ENV_NAME}/bin:$PATH
-RUN conda create --name ${ODAHU_CONDA_ENV_NAME} python --no-default-packages
 
 COPY mlflow/requirements.txt "${ODAHUFLOW_DIR}/"
 RUN . /opt/conda/etc/profile.d/conda.sh && \

--- a/containers/mlflow-toolchain/Dockerfile
+++ b/containers/mlflow-toolchain/Dockerfile
@@ -1,5 +1,5 @@
 #
-#    Copyright 2021 EPAM Systems
+#    Copyright 2019 EPAM Systems
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/containers/mlflow-toolchain/Dockerfile
+++ b/containers/mlflow-toolchain/Dockerfile
@@ -20,7 +20,9 @@ FROM continuumio/miniconda3:${MINICONDA_VERSION}
 ARG ODAHUFLOW_DIR=/opt/odahu-flow
 
 RUN apt-get update --fix-missing && \
-    apt-get install -y wget git gfortran && \
+    apt-get install -y wget git \
+            # numpy install requirements
+            gfortran && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/containers/mlflow-toolchain/Dockerfile
+++ b/containers/mlflow-toolchain/Dockerfile
@@ -26,9 +26,10 @@ RUN apt-get update --fix-missing && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# add model conda env to PATH
+# Create empty conda environemnt for a model dependencies
 ENV ODAHU_CONDA_ENV_NAME=odahu_model
 ENV PATH=/opt/conda/envs/${ODAHU_CONDA_ENV_NAME}/bin:$PATH
+RUN conda create --name ${ODAHU_CONDA_ENV_NAME} python --no-default-packages
 
 COPY mlflow/requirements.txt "${ODAHUFLOW_DIR}/"
 RUN . /opt/conda/etc/profile.d/conda.sh && \

--- a/mlflow/requirements.txt
+++ b/mlflow/requirements.txt
@@ -1,4 +1,4 @@
-odahu-flow-sdk==1.5.0rc7
-odahu-flow-cli==1.5.0rc7
+odahu-flow-sdk==1.6.0
+odahu-flow-cli==1.6.0
 mlflow>=1.13.0
 PyYAML>=3.1.2


### PR DESCRIPTION
- updated odahu-flow dependencies to 1.6.0.
- moved to `continuumio/miniconda3` base image.
- `gfortran` Debian package is needed to install **mlflow/requirements.txt** (for numpy==1.19.2):
![image](https://user-images.githubusercontent.com/49116723/135250275-60f2e1f3-1432-42e0-a913-e26f749c9742.png)

resolves https://github.com/odahu/odahu-flow/issues/622